### PR TITLE
Fix scripts

### DIFF
--- a/db/scripts/dataToCsv_init.py
+++ b/db/scripts/dataToCsv_init.py
@@ -94,7 +94,7 @@ def txtToCSV(input_file, output_file):
 if __name__ == "__main__":
 
     input_dir = "./Oslofjord-data/"
-    output_dir = "./OslofjordDB/db/data"
+    output_dir = "./OslofjordDB-API/db/data"
     
     for filename in os.listdir(input_dir):
         if filename.endswith('.txt'):

--- a/db/scripts/dataToSQL.py
+++ b/db/scripts/dataToSQL.py
@@ -3,8 +3,8 @@ import os
 
 
 def csvToSQL():
-    csv_folder = './OslofjordDB/db/data/' 
-    sql_file = './OslofjordDB/db/scripts/load_data.sql'
+    csv_folder = './OslofjordDB-API/db/data/' 
+    sql_file = './OslofjordDB-API/db/scripts/load_data.sql'
 
     table_name = ['turbidity', 'salinity']
     columns = [['record_time', 'record_number', 'sensor_status', 'turbidity', 'temperature', 'txc_amp', 'c1_amp', 'c2_amp', 'raw_temp', 'location'], 

--- a/db/scripts/main.sh
+++ b/db/scripts/main.sh
@@ -20,10 +20,10 @@ while read -r line; do
 done <<< "$tacl_output"
 
 
-bash /mnt/data/Oslofjord/OslofjordDB/db/scripts/emptyFolder.sh
+bash /mnt/data/Oslofjord/OslofjordDB-API/db/scripts/emptyFolder.sh
 
-bash /mnt/data/Oslofjord/OslofjordDB/db/scripts/ecCopy.sh
+bash /mnt/data/Oslofjord/OslofjordDB-API/db/scripts/ecCopy.sh
 
-python3 /mnt/data/Oslofjord/OslofjordDB/db/scripts/dataToCSV_ec.py
+python3 /mnt/data/Oslofjord/OslofjordDB-API/db/scripts/dataToCSV_ec.py
 
-python3 /mnt/data/Oslofjord/OslofjordDB/db/scripts/insert.py
+python3 /mnt/data/Oslofjord/OslofjordDB-API/db/scripts/insert.py


### PR DESCRIPTION
This fixes the scripts so the instructions in the Oslofjord-init README file work again.

Please check the second patch since I'm unsure about the changes to main.sh: I can't see where this script is called, so I don't know how the `/mnt/data/Oslofjord/OslofjordDB(-API)?` directory is created.