### PR TITLE
Separate table relation update

### DIFF
--- a/db/scripts/track_tables.py
+++ b/db/scripts/track_tables.py
@@ -232,3 +232,25 @@ headers = {"Content-Type": "application/json",
 
 response = requests.post(hasura_url, json=params, headers=headers)
 print(response.content)
+
+
+def create_params(table_name: str, foreign_key: str) -> object:
+    return {
+        "type": "pg_create_object_relationship",
+        "args": {
+            "table": f"{table_name}",
+            "name": "grid",
+            "source": "default",
+            "using": {
+                "foreign_key_constraint_on": [f"{foreign_key}"]
+            }
+        }
+    }
+
+
+grid_id_tables = ["requests", "salinity", "simulations", "turbidity"]
+
+
+for table in grid_id_tables:
+    response = requests.post(hasura_url, json=create_params(table, "grid_id"), headers=headers)
+    print(response.content)

--- a/db/scripts/track_tables.py
+++ b/db/scripts/track_tables.py
@@ -34,14 +34,6 @@ params = {
                     },
                     "comment": "Salinity in the Oslofjord"
                 },
-                "object_relationships": [
-                    {
-                        "name": "grid",
-                        "using": {
-                            "foreign_key_constraint_on": "grid_id"
-                        }
-                    }
-                ],
                 "apollo_federation_config": {
                     "enable": "v1"
                 }
@@ -84,14 +76,6 @@ params = {
                     },
                     "comment": "Turbidity in the Oslofjord"
                 },
-                "object_relationships": [
-                    {
-                        "name": "grid",
-                        "using": {
-                            "foreign_key_constraint_on": "grid_id"
-                        }
-                    }
-                ],
                 "apollo_federation_config": {
                     "enable": "v1"
                 }
@@ -125,14 +109,6 @@ params = {
                     },
                     "comment": "Simulation values for virtual landers"
                 },
-                "object_relationships": [
-                    {
-                        "name": "grid",
-                        "using": {
-                            "foreign_key_constraint_on": "grid_id"
-                        }
-                    }
-                ],
                 "apollo_federation_config": {
                     "enable": "v1"
                 }
@@ -181,14 +157,6 @@ params = {
                     },
                     "comment": "Requests made by the front end to the monitoring component"
                 },
-                "object_relationships": [
-                    {
-                        "name": "grid",
-                        "using": {
-                            "foreign_key_constraint_on": "grid_id"
-                        }
-                    }
-                ],
                 "apollo_federation_config": {
                     "enable": "v1"
                 }


### PR DESCRIPTION
It seems that the table relations cannot be created with the API command `pg_track_tables`. Therefore, I created separate requests that should create the relations now. 